### PR TITLE
feat-3-permissions-for-books_service

### DIFF
--- a/books_service/permissions.py
+++ b/books_service/permissions.py
@@ -1,0 +1,9 @@
+from rest_framework.permissions import BasePermission, SAFE_METHODS
+
+
+class IsAdminOrReadOnly(BasePermission):
+    def has_permission(self, request, view):
+        return bool(
+            (request.method in SAFE_METHODS)
+            or (request.user and request.user.is_staff)
+        )

--- a/books_service/views.py
+++ b/books_service/views.py
@@ -1,9 +1,11 @@
 from rest_framework import viewsets
 
 from books_service.models import Book
+from books_service.permissions import IsAdminOrReadOnly
 from books_service.serializers import BookSerializer
 
 
 class BookViewSet(viewsets.ModelViewSet):
     queryset = Book.objects.all()
     serializer_class = BookSerializer
+    permission_classes = (IsAdminOrReadOnly, )


### PR DESCRIPTION
# Add permissions to the Books Service
- Only admin users can create/update/delete books
- All users (even unauthenticated ones) should be able to list books
- Use JWT token authentication from the users service
